### PR TITLE
Correcting migrations: remove unnecessary migration, which deletes ev…

### DIFF
--- a/db/migrate/20141002104912_event.rb
+++ b/db/migrate/20141002104912_event.rb
@@ -1,5 +1,0 @@
-class Event < ActiveRecord::Migration
-  def change
-    remove_column :events, :event_id
-  end
-end


### PR DESCRIPTION
…ent_id from events table

Next migration - db/migrate/20141002123814_remove_column_from_events.rb - does the same)